### PR TITLE
audiodecoder: Supply audio_buffer to callback

### DIFF
--- a/lib/builders/audiodecoder.js
+++ b/lib/builders/audiodecoder.js
@@ -48,6 +48,6 @@ module.exports = function getAudioDecoder(options, callback){
       }
     }
 
-    callback(new WaveformData(data_object.buffer, WaveformData.adapters.arraybuffer));
+    callback(new WaveformData(data_object.buffer, WaveformData.adapters.arraybuffer), audio_buffer);
   };
 };


### PR DESCRIPTION
Since the audio has already been decoded, it might be useful to have the decoded AudioBuffer along with the waveform, e.g., to avoid loading/decoding the source twice (once for the waveform display, once for playing the audio).