### PR TITLE
Don't let min/max go outside int8 range

### DIFF
--- a/lib/builders/audiodecoder.js
+++ b/lib/builders/audiodecoder.js
@@ -42,10 +42,16 @@ module.exports = function getAudioDecoder(options, callback){
 
       if (sample < min_value){
         min_value = sample;
+        if (min_value < -128) {
+          min_value = -128;
+        }
       }
 
       if (sample > max_value){
         max_value = sample;
+        if (max_value > 127) {
+          max_value = 127;
+        }
       }
 
       if (--scale_counter === 0){


### PR DESCRIPTION
I was seeing some waveforms crossing over oddly; this fixes that.
